### PR TITLE
replacing "Modules" folders with logical folders

### DIFF
--- a/Sources/App/SideProjectSpaceXApp/SideProjectSpaceXApp.xcodeproj/project.pbxproj
+++ b/Sources/App/SideProjectSpaceXApp/SideProjectSpaceXApp.xcodeproj/project.pbxproj
@@ -38,6 +38,27 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		24297E84272733FC00D09110 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 24297E7E272733FC00D09110 /* SpaceXApiModule.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 24198F2726B8535400CF6759;
+			remoteInfo = SpaceXApiModule;
+		};
+		24297E86272733FC00D09110 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 24297E7E272733FC00D09110 /* SpaceXApiModule.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 24198F3026B8535500CF6759;
+			remoteInfo = SpaceXApiModuleTests;
+		};
+		24297E99272734B800D09110 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 24297E7E272733FC00D09110 /* SpaceXApiModule.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 24198F2626B8535400CF6759;
+			remoteInfo = SpaceXApiModule;
+		};
 		246E9F1D26A7529A00BB5E47 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 246E9EFE26A7529600BB5E47 /* Project object */;
@@ -51,27 +72,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 246E9F0526A7529600BB5E47;
 			remoteInfo = SideProjectSpaceXApp;
-		};
-		2490B0072706602400F2AF3A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 2490B0022706602400F2AF3A /* SpaceXApiModule.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 24198F2726B8535400CF6759;
-			remoteInfo = SpaceXApiModule;
-		};
-		2490B0092706602400F2AF3A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 2490B0022706602400F2AF3A /* SpaceXApiModule.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 24198F3026B8535500CF6759;
-			remoteInfo = SpaceXApiModuleTests;
-		};
-		2490B00D2706603100F2AF3A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 2490B0022706602400F2AF3A /* SpaceXApiModule.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 24198F2626B8535400CF6759;
-			remoteInfo = SpaceXApiModule;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -92,6 +92,7 @@
 
 /* Begin PBXFileReference section */
 		24198F4326B857E300CF6759 /* SpaceXApiModule.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SpaceXApiModule.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		24297E7E272733FC00D09110 /* SpaceXApiModule.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SpaceXApiModule.xcodeproj; path = ../../Modules/SpaceXApiModule/SpaceXApiModule.xcodeproj; sourceTree = "<group>"; };
 		24301BA326FA2FA7000C2621 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		246E9F0626A7529600BB5E47 /* SideProjectSpaceXApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SideProjectSpaceXApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		246E9F0926A7529600BB5E47 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -106,7 +107,6 @@
 		246E9F2726A7529A00BB5E47 /* SideProjectSpaceXAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SideProjectSpaceXAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		246E9F2B26A7529A00BB5E47 /* SideProjectSpaceXAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideProjectSpaceXAppUITests.swift; sourceTree = "<group>"; };
 		246E9F2D26A7529A00BB5E47 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		2490B0022706602400F2AF3A /* SpaceXApiModule.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SpaceXApiModule.xcodeproj; path = ../../../Modules/SpaceXApiModule/SpaceXApiModule.xcodeproj; sourceTree = "<group>"; };
 		2492F71526A985DE0063D504 /* NetworkingService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = NetworkingService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		24A7BF4426F21B3700FAB08A /* SpaceXAppDependencies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceXAppDependencies.swift; sourceTree = "<group>"; };
 		E66379C32721EDB100052134 /* nextLaunch.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = nextLaunch.json; sourceTree = "<group>"; };
@@ -153,6 +153,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		24297E7D272733D700D09110 /* Modules */ = {
+			isa = PBXGroup;
+			children = (
+				24297E7E272733FC00D09110 /* SpaceXApiModule.xcodeproj */,
+			);
+			name = Modules;
+			sourceTree = "<group>";
+		};
+		24297E7F272733FC00D09110 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				24297E85272733FC00D09110 /* SpaceXApiModule.framework */,
+				24297E87272733FC00D09110 /* SpaceXApiModuleTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		24301BA126FA2F82000C2621 /* Common */ = {
 			isa = PBXGroup;
 			children = (
@@ -173,7 +190,7 @@
 		246E9EFD26A7529600BB5E47 = {
 			isa = PBXGroup;
 			children = (
-				2490AFF82706600500F2AF3A /* Modules */,
+				24297E7D272733D700D09110 /* Modules */,
 				246E9F0826A7529600BB5E47 /* SideProjectSpaceXApp */,
 				246E9F1F26A7529A00BB5E47 /* SideProjectSpaceXAppTests */,
 				246E9F2A26A7529A00BB5E47 /* SideProjectSpaceXAppUITests */,
@@ -222,23 +239,6 @@
 				246E9F2D26A7529A00BB5E47 /* Info.plist */,
 			);
 			path = SideProjectSpaceXAppUITests;
-			sourceTree = "<group>";
-		};
-		2490AFF82706600500F2AF3A /* Modules */ = {
-			isa = PBXGroup;
-			children = (
-				2490B0022706602400F2AF3A /* SpaceXApiModule.xcodeproj */,
-			);
-			path = Modules;
-			sourceTree = "<group>";
-		};
-		2490B0032706602400F2AF3A /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				2490B0082706602400F2AF3A /* SpaceXApiModule.framework */,
-				2490B00A2706602400F2AF3A /* SpaceXApiModuleTests.xctest */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		2492F71426A985DE0063D504 /* Frameworks */ = {
@@ -352,7 +352,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				2490B00E2706603100F2AF3A /* PBXTargetDependency */,
+				24297E9A272734B800D09110 /* PBXTargetDependency */,
 			);
 			name = SideProjectSpaceXApp;
 			productName = SideProjectSpaceXApp;
@@ -430,8 +430,8 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 2490B0032706602400F2AF3A /* Products */;
-					ProjectRef = 2490B0022706602400F2AF3A /* SpaceXApiModule.xcodeproj */;
+					ProductGroup = 24297E7F272733FC00D09110 /* Products */;
+					ProjectRef = 24297E7E272733FC00D09110 /* SpaceXApiModule.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -444,18 +444,18 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		2490B0082706602400F2AF3A /* SpaceXApiModule.framework */ = {
+		24297E85272733FC00D09110 /* SpaceXApiModule.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = SpaceXApiModule.framework;
-			remoteRef = 2490B0072706602400F2AF3A /* PBXContainerItemProxy */;
+			remoteRef = 24297E84272733FC00D09110 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		2490B00A2706602400F2AF3A /* SpaceXApiModuleTests.xctest */ = {
+		24297E87272733FC00D09110 /* SpaceXApiModuleTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = SpaceXApiModuleTests.xctest;
-			remoteRef = 2490B0092706602400F2AF3A /* PBXContainerItemProxy */;
+			remoteRef = 24297E86272733FC00D09110 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -533,6 +533,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		24297E9A272734B800D09110 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SpaceXApiModule;
+			targetProxy = 24297E99272734B800D09110 /* PBXContainerItemProxy */;
+		};
 		246E9F1E26A7529A00BB5E47 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 246E9F0526A7529600BB5E47 /* SideProjectSpaceXApp */;
@@ -542,11 +547,6 @@
 			isa = PBXTargetDependency;
 			target = 246E9F0526A7529600BB5E47 /* SideProjectSpaceXApp */;
 			targetProxy = 246E9F2826A7529A00BB5E47 /* PBXContainerItemProxy */;
-		};
-		2490B00E2706603100F2AF3A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SpaceXApiModule;
-			targetProxy = 2490B00D2706603100F2AF3A /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Sources/Modules/SpaceXApiModule/SpaceXApiModule.xcodeproj/project.pbxproj
+++ b/Sources/Modules/SpaceXApiModule/SpaceXApiModule.xcodeproj/project.pbxproj
@@ -30,19 +30,26 @@
 			remoteGlobalIDString = 24198F2626B8535400CF6759;
 			remoteInfo = SpaceXApiModule;
 		};
-		E69D0FD62721931900942589 /* PBXContainerItemProxy */ = {
+		24297E912727346400D09110 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = E69D0FD12721931900942589 /* NetworkingService.xcodeproj */;
+			containerPortal = 24297E8C2727346400D09110 /* NetworkingService.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 24C8D9D12632DE2E00887D44;
 			remoteInfo = NetworkingService;
 		};
-		E69D0FD82721931900942589 /* PBXContainerItemProxy */ = {
+		24297E932727346400D09110 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = E69D0FD12721931900942589 /* NetworkingService.xcodeproj */;
+			containerPortal = 24297E8C2727346400D09110 /* NetworkingService.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 24C8D9DA2632DE2E00887D44;
 			remoteInfo = NetworkingServiceTests;
+		};
+		24297E952727348500D09110 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 24297E8C2727346400D09110 /* NetworkingService.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 24C8D9D02632DE2E00887D44;
+			remoteInfo = NetworkingService;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -71,12 +78,12 @@
 		24198F4726B8580900CF6759 /* NetworkingService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = NetworkingService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		24198F4C26B85BFE00CF6759 /* RemoteSpaceXApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSpaceXApiService.swift; sourceTree = "<group>"; };
 		24198F4F26B8698000CF6759 /* LaunchDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchDTO.swift; sourceTree = "<group>"; };
+		24297E8C2727346400D09110 /* NetworkingService.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = NetworkingService.xcodeproj; path = ../NetworkingService/NetworkingService.xcodeproj; sourceTree = "<group>"; };
 		E64964D426E0DBEE00635A94 /* ShipDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShipDTO.swift; sourceTree = "<group>"; };
 		E64964D626E0DEB100635A94 /* RocketDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RocketDTO.swift; sourceTree = "<group>"; };
 		E64964D826E0E5D200635A94 /* Fairings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fairings.swift; sourceTree = "<group>"; };
 		E64964DA26E0E5DB00635A94 /* Core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core.swift; sourceTree = "<group>"; };
 		E64964DC26E0E6F500635A94 /* Links.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Links.swift; sourceTree = "<group>"; };
-		E69D0FD12721931900942589 /* NetworkingService.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = NetworkingService.xcodeproj; path = ../../NetworkingService/NetworkingService.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,7 +109,7 @@
 		24198F1D26B8535400CF6759 = {
 			isa = PBXGroup;
 			children = (
-				E69D0FD02721930E00942589 /* Modules */,
+				24297E8B2727344900D09110 /* Modules */,
 				24198F2926B8535400CF6759 /* SpaceXApiModule */,
 				24198F3426B8535500CF6759 /* SpaceXApiModuleTests */,
 				24198F2826B8535400CF6759 /* Products */,
@@ -169,19 +176,19 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
-		E69D0FD02721930E00942589 /* Modules */ = {
+		24297E8B2727344900D09110 /* Modules */ = {
 			isa = PBXGroup;
 			children = (
-				E69D0FD12721931900942589 /* NetworkingService.xcodeproj */,
+				24297E8C2727346400D09110 /* NetworkingService.xcodeproj */,
 			);
-			path = Modules;
+			name = Modules;
 			sourceTree = "<group>";
 		};
-		E69D0FD22721931900942589 /* Products */ = {
+		24297E8D2727346400D09110 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				E69D0FD72721931900942589 /* NetworkingService.framework */,
-				E69D0FD92721931900942589 /* NetworkingServiceTests.xctest */,
+				24297E922727346400D09110 /* NetworkingService.framework */,
+				24297E942727346400D09110 /* NetworkingServiceTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -213,6 +220,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				24297E962727348500D09110 /* PBXTargetDependency */,
 			);
 			name = SpaceXApiModule;
 			productName = SpaceXApiModule;
@@ -268,8 +276,8 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = E69D0FD22721931900942589 /* Products */;
-					ProjectRef = E69D0FD12721931900942589 /* NetworkingService.xcodeproj */;
+					ProductGroup = 24297E8D2727346400D09110 /* Products */;
+					ProjectRef = 24297E8C2727346400D09110 /* NetworkingService.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -281,18 +289,18 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		E69D0FD72721931900942589 /* NetworkingService.framework */ = {
+		24297E922727346400D09110 /* NetworkingService.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = NetworkingService.framework;
-			remoteRef = E69D0FD62721931900942589 /* PBXContainerItemProxy */;
+			remoteRef = 24297E912727346400D09110 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		E69D0FD92721931900942589 /* NetworkingServiceTests.xctest */ = {
+		24297E942727346400D09110 /* NetworkingServiceTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = NetworkingServiceTests.xctest;
-			remoteRef = E69D0FD82721931900942589 /* PBXContainerItemProxy */;
+			remoteRef = 24297E932727346400D09110 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -345,6 +353,11 @@
 			isa = PBXTargetDependency;
 			target = 24198F2626B8535400CF6759 /* SpaceXApiModule */;
 			targetProxy = 24198F3226B8535500CF6759 /* PBXContainerItemProxy */;
+		};
+		24297E962727348500D09110 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = NetworkingService;
+			targetProxy = 24297E952727348500D09110 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 


### PR DESCRIPTION
replacing "Modules" folders with just logical folders created with the command "Group without folder" from Xcode explorer